### PR TITLE
feat : 월 이름 전역상태관리로 인한 탭바 네비게이션

### DIFF
--- a/Team7/Team7/Views/AppView.swift
+++ b/Team7/Team7/Views/AppView.swift
@@ -6,48 +6,53 @@
 //
 
 import SwiftUI
+import Foundation
+
+class AppState: ObservableObject {
+    @Published var selectedTab: Int = 0
+    @Published var selectedMonthName: String? = nil
+}
 
 struct AppView: View {
+    @StateObject var appState = AppState()
     @State var isSeedDataViewOpen = false
     
     var body: some View {
-        // 태그 관리 화면으로 가는 진입점이 없어서 임시로 추가해 놓음!! 발표 준비할 때는 지우기!!!
-        HStack {
-            Button {
-                isSeedDataViewOpen = true
-            } label: {
-                Label("시드 데이터 관리하기", systemImage: "drop.fill")
-                    .font(.footnote)
+        VStack {
+//            HStack {
+//                Button {
+//                    isSeedDataViewOpen = true
+//                } label: {
+//                    Label("시드 데이터 관리하기", systemImage: "drop.fill")
+//                        .font(.footnote)
+//                }
+//
+//                Spacer()
+//
+//                TagContainerView(tag: "문법", isButtonType: true)
+//            }
+//            .padding()
+//            .sheet(isPresented: $isSeedDataViewOpen) {
+//                SeedDataInsertView()
+//                    .presentationDetents([.medium])
+//            }
+
+            // 탭 뷰
+            TabView(selection: $appState.selectedTab) {
+                MainListView(monthName: appState.selectedMonthName)
+                    .tabItem {
+                        Label("단어장", systemImage: "text.book.closed.fill")
+                    }
+                    .tag(0)
+                
+                ChartsView()
+                    .tabItem {
+                        Label("통계", systemImage: "chart.bar")
+                    }
+                    .tag(1)
             }
-            
-            Spacer()
-            
-            TagContainerView(tag: "문법", isButtonType: true)
         }
-        .padding()
-        .sheet(isPresented: $isSeedDataViewOpen) {
-            SeedDataInsertView()
-                .presentationDetents([.medium])
-        }
-        
-        TabView {
-            MainListView()
-                .tabItem {
-                    Image(systemName: "text.book.closed.fill")
-                    Text("단어장")
-                }
-
-            ChartsView()
-                .tabItem {
-                    Image(systemName: "chart.bar")
-                    Text("통계")
-                }
-        }
-
-        // 태그 관리 화면으로 가는 진입점이 없어서 임시로 추가해 놓음
-//        TagContainerView(isButtonType: true)
-//        ContentView()
-
+        .environmentObject(appState)
     }
 }
 

--- a/Team7/Team7/Views/MainPage/MainListView.swift
+++ b/Team7/Team7/Views/MainPage/MainListView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 import SwiftData
 
 struct MainListView: View {
+    var monthName: String?
+    
     @Environment(\.modelContext) private var context
     @Query var words: [Word]
     @State private var searchText: String = ""
@@ -16,6 +18,7 @@ struct MainListView: View {
     @State private var isShowingDetailView = false
     @State private var selectedWord: Word? = nil
     @State private var selectedTag: String? = nil
+    
 
     var filteredWords: [Word] {
         words.filter { word in
@@ -48,6 +51,9 @@ struct MainListView: View {
                     .padding(.horizontal)
                     .background(RoundedRectangle(cornerRadius: 10).stroke(Color.gray.opacity(0.4)))
                     .padding(.horizontal)
+                    .onAppear {
+                        print("11 : \(monthName)")
+                    }
 
                     MonthFilterBar()
 
@@ -123,6 +129,6 @@ struct MainListView: View {
     }
 }
 
-#Preview {
-    MainListView()
-}
+//#Preview {
+//    MainListView()
+//}

--- a/Team7/Team7/Views/charts/ChartsView.swift
+++ b/Team7/Team7/Views/charts/ChartsView.swift
@@ -26,13 +26,13 @@ struct MonthsData {
 
 struct ChartsView: View {
     @State private var selectedChart: ChartType = .month
+    @EnvironmentObject var appState: AppState  
     @Query var tags: [Tag]
     
     var monthData: [MonthsData] {
         let calendar = Calendar.current
         let grouped = Dictionary(grouping: tags) { a in
-            calendar.component(.month, from: a.createdAt) // 1~12월 숫자
-            
+            calendar.component(.month, from: a.createdAt)
         }
         
         return (1...12).map { monthNumber in
@@ -41,14 +41,10 @@ struct ChartsView: View {
         }
     }
 
-    
     var tagData: [TagData] {
-        Dictionary(grouping: tags, by: { a in a.name })
-            .map { (key, value) in
-                TagData(tagName: key, count: value.count)
-            }
+        Dictionary(grouping: tags, by: { $0.name })
+            .map { TagData(tagName: $0.key, count: $0.value.count) }
     }
-
 
     var body: some View {
         VStack {
@@ -59,27 +55,22 @@ struct ChartsView: View {
             .pickerStyle(.segmented)
             .padding()
             
-            
             if selectedChart == .month {
-                MonthChartView(data: monthData)
-//                    .onAppear {
-//                        print("월별 데이터 : \(monthData)")
-//                    }
+                MonthChartView(data: monthData) { selectedMonth in
+                    appState.selectedMonthName = selectedMonth
+                    appState.selectedTab = 0 // MainListView로 이동
+                }
             } else {
                 TagChartView(data: tagData)
-                    .onAppear{
+                    .onAppear {
                         print("tagData 확인 : \(tagData)")
-                    } // console.log 같이 확인방법 .onAppear는 뷰가 랜더링될때 실행가능하다.
+                    }
             }
-        
-            
-            
+
             Spacer()
         }
         .padding()
-        
     }
-    
 }
 
 #Preview {

--- a/Team7/Team7/Views/charts/ChartsView.swift
+++ b/Team7/Team7/Views/charts/ChartsView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import SwiftData
 
 enum ChartType {
     case month
@@ -35,21 +36,19 @@ extension TagData {
             MonthData(monthName: "12월", count: 3),
         ]
     }
-    
-    
-    static func tagData() -> [TagData] {
-        [
-            TagData(tagName: "CS", count: 10),
-            TagData(tagName: "Swift", count: 10),
-            TagData(tagName: "Java", count: 10),
-            TagData(tagName: "기타", count: 20)
-        ]
-    }
 }
 
 struct ChartsView: View {
     @State private var selectedChart: ChartType = .month
+    @Query var tags: [Tag]
     
+    var tagData: [TagData] {
+        Dictionary(grouping: tags, by: { a in a.name })
+            .map { (key, value) in
+                TagData(tagName: key, count: value.count)
+            }
+    }
+
     var body: some View {
         VStack {
             Picker("차트 타입", selection: $selectedChart) {
@@ -60,12 +59,15 @@ struct ChartsView: View {
             .padding()
             
             
-            // 조건부 랜더링
             if selectedChart == .month {
                 MonthChartView(data: TagData.monthData())
             } else {
-                TagChartView(data: TagData.tagData())
+                TagChartView(data: tagData)
+                    .onAppear{
+                        print("tagData 확인 : \(tagData)")
+                    } // console.log 같이 확인방법 .onAppear는 뷰가 랜더링될때 실행가능하다.
             }
+        
             
             
             Spacer()

--- a/Team7/Team7/Views/charts/ChartsView.swift
+++ b/Team7/Team7/Views/charts/ChartsView.swift
@@ -18,29 +18,29 @@ struct TagData {
     var count: Int
 }
 
-extension TagData {
-    
-    static func monthData() -> [MonthData] {
-        [
-            MonthData(monthName: "1월", count: 4),
-            MonthData(monthName: "2월", count: 6),
-            MonthData(monthName: "3월", count: 9),
-            MonthData(monthName: "4월", count: 3),
-            MonthData(monthName: "5월", count: 4),
-            MonthData(monthName: "6월", count: 6),
-            MonthData(monthName: "7월", count: 9),
-            MonthData(monthName: "8월", count: 3),
-            MonthData(monthName: "9월", count: 4),
-            MonthData(monthName: "10월", count: 6),
-            MonthData(monthName: "11월", count: 9),
-            MonthData(monthName: "12월", count: 3),
-        ]
-    }
+struct MonthsData {
+    var monthName: String
+    var count: Int
 }
+
 
 struct ChartsView: View {
     @State private var selectedChart: ChartType = .month
     @Query var tags: [Tag]
+    
+    var monthData: [MonthsData] {
+        let calendar = Calendar.current
+        let grouped = Dictionary(grouping: tags) { a in
+            calendar.component(.month, from: a.createdAt) // 1~12월 숫자
+            
+        }
+        
+        return (1...12).map { monthNumber in
+            let count = grouped[monthNumber]?.count ?? 0
+            return MonthsData(monthName: "\(monthNumber)월", count: count)
+        }
+    }
+
     
     var tagData: [TagData] {
         Dictionary(grouping: tags, by: { a in a.name })
@@ -48,6 +48,7 @@ struct ChartsView: View {
                 TagData(tagName: key, count: value.count)
             }
     }
+
 
     var body: some View {
         VStack {
@@ -60,7 +61,10 @@ struct ChartsView: View {
             
             
             if selectedChart == .month {
-                MonthChartView(data: TagData.monthData())
+                MonthChartView(data: monthData)
+//                    .onAppear {
+//                        print("월별 데이터 : \(monthData)")
+//                    }
             } else {
                 TagChartView(data: tagData)
                     .onAppear{

--- a/Team7/Team7/Views/charts/MonthChartView.swift
+++ b/Team7/Team7/Views/charts/MonthChartView.swift
@@ -8,14 +8,8 @@
 import SwiftUI
 import Charts
 
-struct MonthData {
-    var monthName: String
-    var count: Int
-}
-
-
 struct MonthChartView: View {
-    var data: [MonthData]
+    var data: [MonthsData]
     
     var body: some View {
         List {
@@ -46,13 +40,13 @@ struct MonthChartView: View {
     }
 }
 
-#Preview {
-    MonthChartView(data: [
-        MonthData(monthName: "1월", count: 4),
-        MonthData(monthName: "2월", count: 6),
-        MonthData(monthName: "3월", count: 9),
-        MonthData(monthName: "4월", count: 3),
-        MonthData(monthName: "5월", count: 4)
-    ])
-}
+//#Preview {
+//    MonthChartView(data: [
+//        MonthData(monthName: "1월", count: 4),
+//        MonthData(monthName: "2월", count: 6),
+//        MonthData(monthName: "3월", count: 9),
+//        MonthData(monthName: "4월", count: 3),
+//        MonthData(monthName: "5월", count: 4)
+//    ])
+//}
 

--- a/Team7/Team7/Views/charts/MonthChartView.swift
+++ b/Team7/Team7/Views/charts/MonthChartView.swift
@@ -8,35 +8,28 @@
 import SwiftUI
 import Charts
 
+
+
 struct MonthChartView: View {
     var data: [MonthsData]
-    
+    var selectMonth: (String) -> Void
     var body: some View {
         List {
             ForEach(data.reversed(), id: \.monthName) { item in
                 HStack {
                     Text("2025년 \(item.monthName)")
-                        .foregroundColor(.primary)
                     Spacer()
-
                     Button {
-                        print("\(item.monthName) 월 클릭")
+                        selectMonth(item.monthName)
                     } label: {
-                        HStack {
-                            Text("\(item.count)개")
-                                .foregroundColor(.blue)
-                        }
+                        Text("\(item.count)개")
+                            .foregroundColor(.blue)
                     }
-                    
-                    
                 }
                 .padding(.vertical, 6)
             }
-            .padding(.top, 8)
-            
         }
         .listStyle(.plain)
-        
     }
 }
 

--- a/Team7/Team7/Views/charts/TagChartView.swift
+++ b/Team7/Team7/Views/charts/TagChartView.swift
@@ -43,6 +43,6 @@ struct TagChartView: View {
     }
 }
 
-#Preview {
-    TagChartView(data: TagData.tagData())
-}
+//#Preview {
+//    TagChartView(data: TagData.tagData())
+//}


### PR DESCRIPTION

월 이름 데이터를 가지고 탭을 이동시켜야 하기에
탭바 태그와 월 이름을 전역으로 상태관리 추가

